### PR TITLE
Fix autoprefixer when using ./m8ke

### DIFF
--- a/m8ke
+++ b/m8ke
@@ -51,20 +51,20 @@ then
        echo $'\n'$THEME_BASE/build.less found
 
         echo Compiling $THEME_BASE.css
-        lessc --silent src/themes/$THEME_BASE/build.less dist/css/$THEME_BASE.css --autoprefix=$AUTOPREFIX
+        lessc --silent src/themes/$THEME_BASE/build.less dist/css/$THEME_BASE.css --autoprefix="$AUTOPREFIX"
 
         echo Compiling $THEME_BASE.min.css $'\n'
-        lessc -x --clean-css --silent src/themes/$THEME_BASE/build.less dist/css/$THEME_BASE.min.css --autoprefix=$AUTOPREFIX
+        lessc -x --clean-css --silent src/themes/$THEME_BASE/build.less dist/css/$THEME_BASE.min.css --autoprefix="$AUTOPREFIX"
     done
 else
     THEME=$1
     echo $'\n'$THEME/build.less found
 
     echo Compiling $THEME.css
-    lessc --silent src/themes/$THEME/build.less dist/css/$THEME.css --autoprefix=$AUTOPREFIX
+    lessc --silent src/themes/$THEME/build.less dist/css/$THEME.css --autoprefix="$AUTOPREFIX"
 
     echo Compiling $THEME.min.css $'\n'
-    lessc -x --clean-css --silent src/themes/$THEME/build.less dist/css/$THEME.min.css --autoprefix=$AUTOPREFIX
+    lessc -x --clean-css --silent src/themes/$THEME/build.less dist/css/$THEME.min.css --autoprefix="$AUTOPREFIX"
 fi
 
 if [ ! -e 'dist/js/' ]


### PR DESCRIPTION
Autoprefixer config wasn't working, it was making less-plugin-autoprefix throw an error.