### PR TITLE
Move td:hover > .fa styles in order to fix them when hovering a table row

### DIFF
--- a/src/themes/m8tro/theme.less
+++ b/src/themes/m8tro/theme.less
@@ -40,6 +40,8 @@ a, .btn, .close {
 }
 
 .table-hover > tbody > tr:hover > td, .table-hover > tbody > tr:hover > th {
+  .fa {color: @body-bg;}
+
   background-color: @m8tro-theme;
   color: @body-bg;
 }
@@ -81,7 +83,6 @@ a.list-group-item:hover, a.list-group-item:focus  {
   border-bottom-color: @body-bg;
 }
 
-td:hover > .fa {color: @body-bg;}
 .fa {color: @m8tro-theme;}
 .fa-home{color:@body-bg;}
 .control-label{font-weight:bolder;font-size: percentage(2 / 3);text-transform: uppercase;padding-right: 10px}


### PR DESCRIPTION
If you hovered over the table row which contains a td that has a Font Awesome icon, it blends into the background and be invisible